### PR TITLE
FriendList.jsの「最近のフレンドのみ」という表示から「関連したフレンドのみ」という表示に変更　2022/07/10

### DIFF
--- a/src/screens/FriendList.js
+++ b/src/screens/FriendList.js
@@ -264,7 +264,7 @@ export const FriendList = ({ navigation }) => {
         onPress={getButtonTrueOrFalse}
         buttonTrueOrFalse={buttonTrueOrFalse}
         trueText={"すべてのフレンド"}
-        falseText={"最近のフレンドのみ"}
+        falseText={"関連したフレンドのみ"}
       />
 
       <FlatList


### PR DESCRIPTION
FriendList.jsの「最近のフレンドのみ」という表示から「関連したフレンドのみ」という表示に変更　2022/07/10